### PR TITLE
No callback when all fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/lib/adaptor/medic-mobile.js
+++ b/lib/adaptor/medic-mobile.js
@@ -358,7 +358,7 @@ exports.prototype = {
               self._previously_sent_uuids[message.uuid] = true;
             }
 
-            ++total_sent;
+            total_sent += _tx_result.total_sent;
             return _callback(); /* Next message */
           });
         },
@@ -372,6 +372,11 @@ exports.prototype = {
 
          if (_e) {
            return _completion_callback.call(self, _e);
+         }
+
+         if (!total_sent) {
+           return _completion_callback.call(self,
+               new Error('All messages were failures.'));
          }
 
          if (total_sent < total_messages) {

--- a/lib/adaptor/medic-mobile.js
+++ b/lib/adaptor/medic-mobile.js
@@ -24,8 +24,7 @@ exports.prototype = {
     this._previously_sent_uuids = {};
     this._http_callback_autoreplies = [];
 
-    this._is_polling = false;
-    this._is_started = false;
+    this._is_running = false;
 
     this._pass =
       (this._options.pass || this._options.password);
@@ -46,9 +45,9 @@ exports.prototype = {
 
   /**
    * @name deliver:
-   *   Deliver the message `_message` to this adaptor's Kujua Lite
+   *   Deliver the message `_message` to this adaptor's medic-webapp
    *   instance. Invoke `_callback(_err, _rx_result)` once the message has
-   *   been successfully received and committed to Kujua Lite's persistent
+   *   been successfully received and committed to medic-webapp's persistent
    *   storage.
    *
    *   The `_message` argument should be an object, containing at least
@@ -160,13 +159,13 @@ exports.prototype = {
    */
   start: function () {
 
-    this._is_polling = true;
-
-    if (!this._is_started) {
-      this._run_transmit_timer();
+    if (this._is_running) {
+      return this;
     }
 
-    this._is_started = true;
+    this._run_transmit_timer();
+    this._is_running = true;
+
     return this;
   },
 
@@ -177,7 +176,8 @@ exports.prototype = {
    */
   stop: function () {
 
-    this._is_polling = false;
+    clearTimeout(this.timeout);
+    this._is_running = false;
     return this;
   },
 
@@ -264,7 +264,7 @@ exports.prototype = {
 
     var self = this;
 
-    setTimeout(function () {
+    self.timeout = setTimeout(function () {
 
       self._handle_transmit_timer(function (_err) {
 
@@ -274,15 +274,10 @@ exports.prototype = {
             Are we still supposed to be polling? If so, use tail recursion
             to invoke ourself again, and re-enter the `setTimeout` delay.  */
 
-        if (self._is_polling) {
+        if (self._is_running) {
           return self._run_transmit_timer();
         }
 
-        /* Termination case:
-            We've been asked to stop polling; let others know
-            that we've indeed stopped, and don't repeat this procedure. */
-
-        self._is_started = false;
       });
 
     }, self._poll_interval);
@@ -292,7 +287,7 @@ exports.prototype = {
 
   /**
    * @name _handle_transmit_timer:
-   *   Run one polling cycle, asking Kujua Lite for messages to transmit.
+   *   Run one polling cycle, asking medic-webapp for messages to transmit.
    *   If we find any, invoke `_handler` to allow the underlying driver
    *   to actually transmit the message data, run any SMSsync-style
    *   HTTP callbacks that are requested. Once there is no more work
@@ -339,8 +334,8 @@ exports.prototype = {
           }
 
           /* Invoke handler:
-              The handler accepts a single message only, but Kujua
-              Lite currently sends a batch of messages and wants the
+              The handler accepts a single message only, but medic-webapp
+              currently sends a batch of messages and wants the
               HTTP callbacks to be run only after all messages are sent
               successfully. We loop through the messages asynchronously,
               and keep track of the transmit results along the way. Once
@@ -383,7 +378,7 @@ exports.prototype = {
 
            /* FIXME:
                 We need a better way to handle transmit failures for
-                Kujua Lite. Currently, our choices are to either
+                medic-webapp. Currently, our choices are to either
                 (a) retry the whole batch, potentially spamming the
                 other people who have messages in the batch, or (b)
                 treat all delivery failures as permenant failures. We're
@@ -402,7 +397,7 @@ exports.prototype = {
          /* Transmit successful:
              The underlying driver was able to send the message.
              Now, invoke the emulated SMSsync HTTP callbacks, which
-             will allow Kujua Lite to perform its post-transmit work. */
+             will allow medic-webapp to perform its post-transmit work. */
 
          return self._perform_http_callbacks(
            _poll_results.callback, 1, _completion_callback
@@ -482,13 +477,12 @@ exports.prototype = {
     var request = {
       url: url,
       headers: (o.headers || {}),
-      method: (o.method || 'GET'),
       body: JSON.stringify(_callback_object.data || {})
     };
 
     self._debug_http_request(request);
 
-    http_request(request, function (_err, _resp, _body) {
+    http_request.get(request, function (_err, _resp, _body) {
 
       var body = {};
 
@@ -646,7 +640,7 @@ exports.prototype = {
 
  /**
   * @name _poll_for_transmit:
-  *   Ask the attached Kujua Lite instance if there are any
+  *   Ask the attached medic-webapp instance if there are any
   *   outgoing messages. If there are any, call `_callback`
   *   with an array for its second parameter. If there aren't any,
   *   call `_callback` with an empty array for its second parameter.
@@ -664,7 +658,7 @@ exports.prototype = {
 
     self._debug_http_request(request);
 
-    http_request(request, function (_err, _resp, _body) {
+    http_request.get(request, function (_err, _resp, _body) {
 
       var rv = {};
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An SMS transport API for Medic Mobile's mHealth platform",
   "main": "lib/factory.js",
   "scripts": {
-    "test": "echo 'No tests available yet' && exit 1"
+    "test": "mocha --timeout 200 test/**"
   },
   "dependencies": {
     "async": "0.x",
@@ -13,6 +13,10 @@
     "underscore": "1.x",
     "request": "2.x",
     "node-gammu-json": "0.x"
+  },
+  "devDependencies": {
+    "sinon": "1.14.x",
+    "chai": "2.1.x"
   },
   "readme": "README.md",
   "repository": "http://github.com/browndav/medic-transport.git",

--- a/test/adaptor/medic-mobile-test.js
+++ b/test/adaptor/medic-mobile-test.js
@@ -1,0 +1,282 @@
+var chai = require('chai'),
+    request = require('request'),
+    sinon = require('sinon'),
+    adaptor = require('../../lib/adaptor.js'),
+    assert = chai.assert,
+    mock_http = require('../request-mocker.js');
+chai.config.includeStack = true;
+
+describe('medic-mobile', function() {
+  var TEST_MESSAGE = {content:'', from:'', timestamp:''},
+      TEST_URL_ROOT = 'http://localhost/nonsense',
+      TEST_CALLBACK_OBJ = {url:'http://localhost:5999/weird-callback',
+          headers:{}, body:'{"docs":["asdf","123"]}'};
+      mm = null;
+
+  beforeEach(function() {
+    mm = adaptor.create('medic-mobile',
+        {debug:false, pass:'secret', url:TEST_URL_ROOT, interval:100});
+  });
+
+  afterEach(function() {
+    if(mm) mm.stop();
+    mock_http.restore();
+  });
+
+  var error_and_done = function(done, error_message) {
+    return function() { return done(new Error(error_message)); };
+  }
+
+  var MESSAGES_TO_SEND_ONCE = [
+    {
+          payload:{messages:[
+              {uuid:0, message:'a', to:'0', random_key:'should be ignored'},
+              {uuid:1, message:'b', to:'1'},
+              {uuid:2, message:'c', to:'2'}]},
+          callback:{data:{docs:['asdf', '123']}, options:{protocol:'http', host:'localhost', port:5999, path:'/weird-callback'}}},
+    {}
+  ];
+
+  describe('receiving', function() {
+    it('should poll by GETting /add', function(done) {
+      sinon.stub(request, 'get', function(options) {
+        assert.equal(options.url, TEST_URL_ROOT + '/add');
+        return done();
+      });
+      mm.start();
+    });
+    it('should call transmit handler once for each message when all sent ok',
+        function(done) {
+      this.timeout(0);
+
+      mock_http.mock({
+        'GET http://localhost/nonsense/add': MESSAGES_TO_SEND_ONCE,
+        'GET http://localhost:5999/weird-callback': [
+          function(url, options) {
+            assert.deepEqual(options, TEST_CALLBACK_OBJ);
+          },
+          error_and_done(done, "Should only make one callback.")
+        ]
+      });
+
+      var transmit_handler_calls = [];
+      mm.register_transmit_handler(function(message, callback) { // TODO not reuiqred
+        var actual, i,
+            ALPHABET = 'abc';
+        transmit_handler_calls.push(message);
+        if(transmit_handler_calls.length === 3) {
+          for(i=0; i<3; ++i) {
+            actual = transmit_handler_calls[i];
+            assert.equal(actual.uuid, i);
+            assert.equal(actual.content, ALPHABET.charAt(i));
+            assert.equal(actual.to, ""+i);
+            assert.ok(actual.timestamp);
+            assert.notOk(actual.random_key);
+          }
+        }
+        callback(null, { status:'success', total_sent:transmit_handler_calls.length });
+      });
+
+      mm.start();
+
+      setTimeout(function() {
+        assert.equal(mock_http.handlers.GET['http://localhost:5999/weird-callback'].count, 1);
+        done();
+      }, 200);
+    });
+    it('should call transmit handler for messages marked "failure"', function(done) {
+      mock_http.mock({
+        'GET http://localhost/nonsense/add': MESSAGES_TO_SEND_ONCE,
+        'GET http://localhost:5999/weird-callback': [
+          function(url, options) {
+            assert.deepEqual(options, TEST_CALLBACK_OBJ);
+            return done();
+          },
+          error_and_done(done, "Should only make one callback.")
+        ]
+      });
+
+      var transmit_handler_called = false;
+      mm.register_transmit_handler(function(message, callback) {
+        //done(new Error("Should not call the transmit handler for a bad message!"));
+        callback(false, { status:'failure' });
+      });
+      mm.register_error_handler(function(error) {
+        return done(error);
+      });
+
+      // when
+      mm.start();
+    });
+    it('should not call transmit handler when there are transmit errors', function(done) {
+      // setup
+      this.timeout(0);
+      mock_http.mock({
+        'GET http://localhost/nonsense/add': MESSAGES_TO_SEND_ONCE
+      });
+      mm.register_transmit_handler(function(message, callback) {
+        callback(new Error("Manufactured error for testing"));
+      });
+
+      // when
+      mm.start();
+
+      // then
+      setTimeout(done, 200);
+    });
+    it('should not call transmit error handler when there are transmit errors', function(done) {
+      // setup
+      this.timeout(0);
+      mock_http.mock({
+        'GET http://localhost/nonsense/add': MESSAGES_TO_SEND_ONCE
+      });
+      mm.register_transmit_handler(function(message, callback) {
+        callback(new Error("Manufactured error for testing"));
+      });
+      var error_handler_call_count = 0;
+      mm.register_error_handler(function(error) {
+        assert.equal(error.toString(), "Error: Manufactured error for testing");
+        ++error_handler_call_count;
+      });
+
+      // when
+      mm.start();
+
+      // then
+      setTimeout(function() {
+        assert.equal(error_handler_call_count, 0);
+        done();
+      }, 200);
+    });
+    // TODO it's actually expected that messages which returned status
+    // `failure` *should* be retried...but that's not what the current
+    // implementation does.  So this test is there to ensure the
+    // behaviour is not inadvertantly changed.
+    it('should not retry messages which return status `failure`', function(done) {
+      // setup
+      this.timeout(0);
+      mock_http.mock({
+          'GET http://localhost/nonsense/add': MESSAGES_TO_SEND_ONCE,
+          'GET http://localhost:5899/weird-callback': error_and_done(done,
+              'Should not have callback with failed messages.')
+      });
+      var sendAttempts = 0;
+
+      var transmit_handler_called = false;
+      mm.register_transmit_handler(function(message, callback) {
+        ++sendAttempts;
+        callback(false, { status:'failure' });
+      });
+
+      // when
+      mm.start();
+
+      // then
+      setTimeout(function() {
+        assert.equal(sendAttempts, 3);
+        return done();
+      }, 200);
+    });
+  });
+  describe('.deliver()', function() {
+    it('should call supplied callback if a good message is supplied', function(done) {
+      // when
+      mm.deliver(TEST_MESSAGE, function(error, response) {
+        // then
+        return done();
+      });
+    });
+    it('should POST to /add', function(done) {
+      mock_http.mock({ 'POST http://localhost/nonsense/add': {} });
+
+      // when
+      mm.deliver(TEST_MESSAGE, function(error, response) {
+        if(error) return done(error);
+
+        // then
+        assert.deepEqual(response, {total_sent:1, status:'success'});
+
+        var args = request.post.firstCall.args;
+        assert.equal(args.length, 2);
+        assert.equal(args[0].url, TEST_URL_ROOT + '/add');
+        assert.equal(request.post.callCount, 1);
+        assert.notOk(request.get.called);
+        return done();
+      });
+    });
+    it('should report success to the callback URL', function(done) {
+      mock_http.mock({
+        'POST http://localhost/nonsense/add': {
+            payload: {
+              messages:[{}]
+            },
+            callback: { data:
+                { docs:['asdf', '123'] },
+                options:{protocol:'http', host:'localhost', port:5999,
+                    path:'/weird-callback'} } },
+        'GET http://localhost:5999/weird-callback':
+            function(request, options) {
+              assert.equal(request,
+                  'http://localhost:5999/weird-callback');
+              // for some reason, the body should equal the data we passed
+              // in the `callback` field of the `POST` to `/add`
+              assert.equal(options.body, '{"docs":["asdf","123"]}');
+              return done();
+            }
+      });
+
+      mm.deliver(TEST_MESSAGE, function(error, response) {});
+    });
+    it('should report success to the callback URL once for each batch', function(done) {
+      // setup
+      this.timeout(0);
+      mock_http.mock({
+        'POST http://localhost/nonsense/add': {
+            payload: {
+              messages:[{}, {}, {}]
+            },
+            callback: { data:
+                { docs:['asdf', '123'] },
+                options:{protocol:'http', host:'localhost', port:5999,
+                    path:'/weird-callback'} } },
+        'GET http://localhost:5999/weird-callback':
+            function(request, options) {
+              assert.equal(request,
+                  'http://localhost:5999/weird-callback');
+              // for some reason, the body should equal the data we passed
+              // in the `callback` field of the `POST` to `/add`
+              assert.equal(options.body, '{"docs":["asdf","123"]}');
+            }
+      });
+
+      // when
+      mm.deliver(TEST_MESSAGE, function(error, response) {});
+
+      // then
+      setTimeout(function() {
+        assert.equal(mock_http.handlers.GET['http://localhost:5999/weird-callback'].count, 1);
+        done();
+      }, 200);
+    });
+    // TODO we probably do want to be retrying these, but the current
+    // implementation does not.
+    it('should not retry failed deliveries', function(done) {
+      // setup
+      var deliver_callback_count = 0;
+      this.timeout(0);
+      mock_http.mock({});
+
+      // when
+      mm.deliver(TEST_MESSAGE, function(error, response) {
+        ++deliver_callback_count;
+        assert.ok(error);
+      });
+
+      // then
+      setTimeout(function() {
+        assert.equal(deliver_callback_count, 1);
+        done();
+      }, 200);
+    });
+  });
+});

--- a/test/adaptor/medic-mobile-test.js
+++ b/test/adaptor/medic-mobile-test.js
@@ -55,7 +55,7 @@ describe('medic-mobile', function() {
           function(url, options) {
             assert.deepEqual(options, TEST_CALLBACK_OBJ);
           },
-          error_and_done(done, "Should only make one callback.")
+          error_and_done(done, 'Should only make one callback.')
         ]
       });
 
@@ -69,7 +69,7 @@ describe('medic-mobile', function() {
             actual = transmit_handler_calls[i];
             assert.equal(actual.uuid, i);
             assert.equal(actual.content, ALPHABET.charAt(i));
-            assert.equal(actual.to, ""+i);
+            assert.equal(actual.to, ''+i);
             assert.ok(actual.timestamp);
             assert.notOk(actual.random_key);
           }
@@ -92,13 +92,12 @@ describe('medic-mobile', function() {
             assert.deepEqual(options, TEST_CALLBACK_OBJ);
             return done();
           },
-          error_and_done(done, "Should only make one callback.")
+          error_and_done(done, 'Should only make one callback.')
         ]
       });
 
       var transmit_handler_called = false;
       mm.register_transmit_handler(function(message, callback) {
-        //done(new Error("Should not call the transmit handler for a bad message!"));
         callback(false, { status:'failure' });
       });
       mm.register_error_handler(function(error) {
@@ -115,7 +114,7 @@ describe('medic-mobile', function() {
         'GET http://localhost/nonsense/add': MESSAGES_TO_SEND_ONCE
       });
       mm.register_transmit_handler(function(message, callback) {
-        callback(new Error("Manufactured error for testing"));
+        callback(new Error('Manufactured error for testing'));
       });
 
       // when
@@ -131,11 +130,11 @@ describe('medic-mobile', function() {
         'GET http://localhost/nonsense/add': MESSAGES_TO_SEND_ONCE
       });
       mm.register_transmit_handler(function(message, callback) {
-        callback(new Error("Manufactured error for testing"));
+        callback(new Error('Manufactured error for testing'));
       });
       var error_handler_call_count = 0;
       mm.register_error_handler(function(error) {
-        assert.equal(error.toString(), "Error: Manufactured error for testing");
+        assert.equal(error.toString(), 'Error: Manufactured error for testing');
         ++error_handler_call_count;
       });
 

--- a/test/request-mocker-test.js
+++ b/test/request-mocker-test.js
@@ -1,0 +1,294 @@
+var chai = require('chai'),
+    assert = chai.assert,
+    request = require('request'),
+    sinon = require('sinon'),
+    mock_request = require('./request-mocker.js'),
+    AUTOJSON = false;
+
+describe('mocker', function() {
+  beforeEach(function() {
+    this.timeout(500);
+  });
+
+  afterEach(function() {
+    mock_request.restore();
+  });
+
+  it('should allow simple mocks with an object', function(done) {
+    // given
+    mock_request.mock({
+      'GET http://example.com/path': [{content:true}]
+    });
+
+    // when
+    request.get('http://example.com/path', function(err, resp, body) {
+      // then
+      assert.equal(err, null);
+      if(AUTOJSON) {
+        assert.deepEqual(body, {content:true});
+      } else {
+        assert.equal(body, '{"content":true}');
+      }
+      done();
+    });
+  });
+  it('should repeat final response for multiple requests', function(done) {
+    // given
+    mock_request.mock({
+      'GET http://example.com/path': [{content:1}, {content:2}, {content:'everything else'}]
+    });
+
+    // when
+    request.get('http://example.com/path', function(err, resp, body) {
+      // then
+      if(AUTOJSON) {
+        assert.deepEqual(body.content, 1);
+      } else {
+        assert.equal(body, '{"content":1}');
+      }
+    });
+    // and
+    request.get('http://example.com/path', function(err, resp, body) {
+      // then
+      if(AUTOJSON) {
+        assert.deepEqual(body.content, 2);
+      } else {
+        assert.equal(body, '{"content":2}');
+      }
+    });
+    // and
+    request.get('http://example.com/path', function(err, resp, body) {
+      // then
+      if(AUTOJSON) {
+        assert.deepEqual(body.content, 'everything else');
+      } else {
+        assert.equal(body, '{"content":"everything else"}');
+      }
+    });
+    // and
+    request.get('http://example.com/path', function(err, resp, body) {
+      // then
+      if(AUTOJSON) {
+        assert.deepEqual(body.content, 'everything else');
+      } else {
+        assert.equal(body, '{"content":"everything else"}');
+      }
+      done();
+    });
+  });
+  it('should return an error for unmocked paths', function(done) {
+    // given
+    mock_request.mock({
+      'GET http://example.com/path': [{content:1}, {content:2}, {content:'everything else'}]
+    });
+
+    // when
+    request.get('http://example.com/bad_path', function(err, resp, body) {
+      // then
+      assert.ok(err);
+      done();
+    });
+  });
+  it('should call functions listed as responses', function(done) {
+    // given
+    mock_request.mock({
+      'GET http://example.com/path': new function() { done(); }
+    });
+
+    // when
+    request.get('http://example.com/path', function() {});
+  });
+  it('should provide request details to function handlers', function(done) {
+    // given
+    mock_request.mock({
+      'GET http://example.com/path': function(url, options) {
+        assert.equal(url, 'http://example.com/path');
+        assert.ok(options);
+        done();
+      }
+    });
+
+    // when
+    request.get('http://example.com/path');
+  });
+  it('should provide support for POST requests wihtout a body', function(done) {
+    // given
+    mock_request.mock({
+      'POST http://example.com/path': [{content:true}]
+    });
+
+    // when
+    request.post('http://example.com/path', function(err, resp, body) {
+      // then
+      assert.equal(err, null);
+      if(AUTOJSON) {
+        assert.deepEqual(body, {content:true});
+      } else {
+        assert.equal(body, '{"content":true}');
+      }
+      done();
+    });
+  });
+  it('should provide support for POST requests with a body', function(done) {
+    // given
+    mock_request.mock({
+      'POST http://example.com/path': [{content:true}]
+    });
+
+    // when
+    request.post('http://example.com/path', { here:'body' }, function(err, resp, body) {
+      // then
+      assert.equal(err, null);
+      if(AUTOJSON) {
+        assert.deepEqual(body, {content:true});
+      } else {
+        assert.equal(body, '{"content":true}');
+      }
+      done();
+    });
+  });
+  it('should provide support for PUT requests', function(done) {
+    // given
+    mock_request.mock({
+      'PUT http://example.com/path': [{content:true}]
+    });
+
+    // when
+    request.put('http://example.com/path', function(err, resp, body) {
+      // then
+      assert.equal(err, null);
+      if(AUTOJSON) {
+        assert.deepEqual(body, {content:true});
+      } else {
+        assert.equal(body, '{"content":true}');
+      }
+      done();
+    });
+  });
+  it('should not be confused between config for GET and POST', function(done) {
+    // given
+    mock_request.mock({
+      'POST http://example.com/path': [{content:true}]
+    });
+
+    // when
+    request.get('http://example.com/path', function(err, resp, body) {
+      // then
+      assert.ok(err);
+      done();
+    });
+  });
+  it('should accept URLs passed in `options` object', function(done) {
+    // given
+    mock_request.mock({
+      'GET http://example.com/path': [{content:true}]
+    });
+
+    // when
+    request.get({url:'http://example.com/path'}, function(err, resp, body) {
+      // then
+      assert.equal(err, null);
+      if(AUTOJSON) {
+        assert.equal(body.content, true);
+      } else {
+        assert.equal(body, '{"content":true}');
+      }
+      done();
+    });
+  });
+  it('should count requests', function() {
+    // given
+    mock_request.mock({
+      'GET http://once': {},
+      'GET http://twice': {},
+      'GET http://thrice': {}
+    });
+
+    // when
+    request.get('http://once');
+
+    request.get('http://twice');
+    request.get('http://twice');
+
+    request.get('http://thrice');
+    request.get('http://thrice');
+    request.get('http://thrice');
+
+    // then
+    assert.equal(mock_request.handlers.GET['http://once'].count, 1);
+    assert.equal(mock_request.handlers.GET['http://twice'].count, 2);
+    assert.equal(mock_request.handlers.GET['http://thrice'].count, 3);
+  });
+  it('should support catch-all URLs', function() {
+    // given
+    mock_request.mock({
+      'GET http://something/or-other/specific':'specific',
+      'GET http://something/or-other/**':'catch-all' });
+
+    // when
+    request.get('http://something/or-other/specific', function(err, resp, body) {
+      // then
+      if(AUTOJSON) {
+        assert.equal(body, 'specific');
+      } else {
+        assert.equal(body, '"specific"');
+      }
+    });
+
+    // when
+    request.get('http://something/or-other/', function(err, resp, body) {
+      // then
+      if(AUTOJSON) {
+        assert.equal(body, 'catch-all');
+      } else {
+        assert.equal(body, '"catch-all"');
+      }
+    });
+
+    // when
+    request.get('http://something/or-other/random', function(err, resp, body) {
+      // then
+      if(AUTOJSON) {
+        assert.equal(body, 'catch-all');
+      } else {
+        assert.equal(body, '"catch-all"');
+      }
+    });
+
+    // when
+    request.get('http://something/or-other', function(err, resp, body) {
+      // then
+      if(AUTOJSON) {
+        assert.equal(body, 'catch-all');
+      } else {
+        assert.equal(body, '"catch-all"');
+      }
+    });
+
+    // when
+    request.get('http://something', function(err, resp, body) {
+      // then
+      assert.equal(err.toString(), 'Error: No mock found for GET at: http://something'); });
+  });
+/*  it('should support requests made via `request()`', function(done) {
+    // given
+    mock_request.mock({
+      'GET http://example.com/path': [{content:true}]
+    });
+
+    // when
+    request({url:'http://example.com/path'},
+        function(err, resp, body) {
+      assert.equal(err, null);
+      assert.equal(body.content, true);
+      done();
+    });
+    // and
+    request({method:'POST', url:'http://example.com/path'},
+        function(err, resp, body) {
+      assert.ok(err);
+      assert.notEqual(body.content, true);
+      done();
+    });
+  });*/
+});

--- a/test/request-mocker.js
+++ b/test/request-mocker.js
@@ -1,0 +1,135 @@
+var request = require('request'),
+    _ = require('underscore'),
+    sinon = require('sinon'),
+    DEBUG = false,
+    AUTOJSON = false,
+    SUPPORTED_VERBS = ['get', 'post', 'put'],
+    WILDCARD_MATCH = new RegExp(/.*\*\*$/);
+
+module.exports = (function() {
+  var self = {},
+  handle_action = function(handler, url, options, callback) {
+    if(DEBUG) console.log('handle_action() :: url=' + url);
+
+    var hit_count = handler.count++,
+        actions = handler.actions,
+        response_body;
+
+    if(_.isArray(handler.actions)) {
+      if(hit_count < actions.length) {
+        response_body = perform_action(actions[hit_count], url, options);
+      } else {
+        response_body = perform_action(actions[actions.length-1], url, options);
+      }
+    } else response_body = perform_action(actions, url, options);
+
+    // TODO set response-type as JSON
+    callback(null, {
+            headers: { 'Content-type': 'application/json' },
+            statusCode:200 },
+        AUTOJSON ? response_body : JSON.stringify(response_body));
+  },
+  perform_action = function(action, url, options) {
+    if(typeof action === 'function') {
+      if(DEBUG) console.log('perform_action() returning result of "action":' + action);
+      return action(url, options);
+    } else if(typeof action === 'string') {
+      if(DEBUG) console.log('perform_action() returning "action":' + action);
+      return action;
+    } else {
+      if(DEBUG) console.log('perform_action() returning "action":' + JSON.stringify(action));
+      return action;
+    }
+  },
+  stubs_for = function(verbs) {
+    _.each(verbs, function(verb) {
+      var VERB = verb.toUpperCase();
+      sinon.stub(request, verb, function(url, options, callback) {
+        if(DEBUG) console.log('request() :: initial args = [' +
+            typeof url + ', ' +
+            typeof options + ', ' +
+            typeof callback + ']');
+        if(typeof url === 'object') {
+          if(DEBUG) console.log('Received url as `options` object - remapping...');
+          if(typeof callback !== 'undefined') {
+            throw new Error('Too many args supplied.');
+          }
+          callback = options;
+          options = url;
+          url = options.url;
+        }
+        if(typeof callback === 'undefined') {
+          // TODO check if including `options` in convenience methods is
+          // actually supported
+          callback = options;
+          options = {};
+        }
+        callback = callback || function() {};
+
+        if(DEBUG) console.log('request() :: remappd args = [' +
+            typeof url + ', ' +
+            typeof options + ', ' +
+            typeof callback + ']');
+        if(DEBUG) console.log(VERB + ':' +
+            ' url=' + JSON.stringify(url) +
+            ' options=' + JSON.stringify(options) +
+            ' callback=' + JSON.stringify(callback));
+
+        var handler = self.handlers[VERB][url];
+        if(!handler) {
+          // search for catch-all handler
+          _.each(_.keys(self.handlers[VERB]), function(matcher) {
+            if(WILDCARD_MATCH.test(matcher)) {
+              var without_stars = matcher.slice(0, -2);
+              if(without_stars === url.slice(0, without_stars.length)) {
+                handler = self.handlers[VERB][matcher];
+                return;
+              }
+
+              if(without_stars.slice(-1) !== '/') return;
+
+              var without_stars_and_slash = without_stars.slice(0, -1);
+              if(without_stars_and_slash === url) {
+                handler = self.handlers[VERB][matcher];
+                return;
+              }
+            }
+          });
+        }
+        if(!handler) {
+          callback(new Error('No mock found for ' + VERB + ' at: ' + url));
+          return;
+        }
+        if(DEBUG) console.log('Found handler for ' + VERB + ' to ' + url + '!');
+        return handle_action(handler, url, options, callback);
+      });
+    });
+  };
+
+  self.restore = function() {
+    self.handlers = {};
+    _.each(SUPPORTED_VERBS, function(verb) {
+      request[verb].restore && request[verb].restore();
+      self.handlers[verb.toUpperCase()] = {};
+    });
+  };
+  self.mock = function(behaviour) {
+    self.restore();
+    _.mapObject(behaviour, function(resp, req) {
+      if(DEBUG) console.log('Mapping: ' + req + ' -> ' + resp);
+      var pieces = req.split(' ', 2),
+          verb = pieces[0].toUpperCase(),
+          url = pieces[1];
+      if(!verb || !url) {
+        throw new Error('Both VERB and URL to mock.  Supplied:' + req);
+      }
+      if(DEBUG) console.log('  verb: ' + verb + ', url: ' + url);
+      self.handlers[verb][url] = { count:0, actions:resp };
+    });
+    stubs_for(SUPPORTED_VERBS);
+    // TODO need to stub the global `request()` method
+  };
+
+  return self;
+}());
+


### PR DESCRIPTION
Builds on https://github.com/medic/medic-transport/pull/11 to fix bug mentioned in https://github.com/medic/medic-webapp/issues/818: disable HTTP callback when no message transmissions were successful