### PR TITLE
Add underscore import to lib/transport.js

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -1,6 +1,7 @@
 
 var async = require('async'),
     jsdump = require('jsDump'),
+    _ = require('underscore'),
     driver = require('./driver'),
     adaptor = require('./adaptor');
 


### PR DESCRIPTION
Added missing import - `_` is used at the `exports.create` function; not sure how it ever worked before.